### PR TITLE
Upgrade to stash 3.5 to fix scheduling issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Jenkins Pull-Request Integration
 
 This started as a project "how difficult could it be" to create a integration between Stash and Jenkins CI. 
-So I decided to build a small plugin for Stash inspired by all the examples provided by Atlassian, 
-it's still working progress and it only tested with Stash 2.10.1 and Jenkins CI 1.509.2
+So I decided to build a small plugin for Stash inspired by all the examples provided by Atlassian
 
 This stash plugin hook into create/update/reopen pull-request to trigger a build on Jenkins CI through the API. 
 3 hooks listing on events "PullRequestOpenedEvent", "PullRequestRescopedEvent" and "PullRequestReopenedEvent" and 
@@ -67,11 +66,13 @@ If one CI server fail to process the request it will try the next in the list un
 
 ##  Upgrade from 1.0.5 to 1.0.6
 - Added support for passing the pull-request url to a job parameter to give full traceability both ways.
- 
-Updated [02-01-2014]
 
-* Fixed an issue with null point when computing the encryption key. 
-* Upgrade Stash to version 2.8.2
+##  Upgrade from 1.0.6 to 1.0.7
+- The scheduler is now using the latest changes when it run, instead of using the change set when it was scheduled.
+
+##  Upgrade from 1.0.7 to 1.0.8
+- Upgrade to Stash 3.5
+- Introduce a setting to "Disable automatic build" by default when open or re-open a pull-request
 
 Flemming Harms
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	
 	<groupId>com.harms.stash</groupId>
 	<artifactId>jenkins-integration-plugin</artifactId>
 	<version>1.0.7-SNAPSHOT</version>
 	<packaging>atlassian-plugin</packaging>
-	
 	<repositories>
 		<repository>
 			<id>atlassian-public</id>
@@ -24,7 +22,6 @@
 			</releases>
 		</repository>
 	</repositories>
-
 	<scm>
 		<connection>scm:https://fharms@bitbucket.org/fharms/stash-pullrequest-jenkins.git</connection>
 		<developerConnection>scm:https://fharms@bitbucket.org/fharms/stash-pullrequest-jenkins.git</developerConnection>
@@ -58,9 +55,9 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-		  <groupId>com.atlassian.sal</groupId>
-		  <artifactId>sal-api</artifactId>
-		  <scope>provided</scope>
+			<groupId>com.atlassian.sal</groupId>
+			<artifactId>sal-api</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.atlassian.event</groupId>
@@ -68,24 +65,13 @@
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.atlassian.stash</groupId>
-			<artifactId>stash-util</artifactId>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.atlassian.stash</groupId>
-			<artifactId>stash-page-objects</artifactId>
-			<scope>provided</scope>
-			<exclusions>
-				<exclusion>
-					<artifactId>log4j-over-slf4j</artifactId>
-					<groupId>org.slf4j</groupId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>com.atlassian.soy</groupId>
 			<artifactId>soy-template-renderer-api</artifactId>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.atlassian.scheduler</groupId>
+			<artifactId>atlassian-scheduler-api</artifactId>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -108,11 +94,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.slf4j</groupId>
-			<artifactId>slf4j-log4j12</artifactId>
-			<version>1.6.1</version>
-		</dependency>
-		<dependency>
 			<groupId>com.atlassian.plugins</groupId>
 			<artifactId>atlassian-plugins-webresource</artifactId>
 		</dependency>
@@ -121,7 +102,6 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
-
 		<!-- these are here to override transitive versions -->
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
@@ -133,7 +113,6 @@
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 		</dependency>
-
 	</dependencies>
 	<build>
 		<plugins>
@@ -155,9 +134,10 @@
 			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -170,13 +150,48 @@
 				<artifactId>maven-amps-plugin</artifactId>
 				<version>${amps.version}</version>
 				<extensions>true</extensions>
-			 </plugin>
+			</plugin>
 		</plugins>
+		<pluginManagement>
+			<plugins>
+				<!--This plugin's configuration is used to store Eclipse m2e settings 
+					only. It has no influence on the Maven build itself. -->
+				<plugin>
+					<groupId>org.eclipse.m2e</groupId>
+					<artifactId>lifecycle-mapping</artifactId>
+					<version>1.0.0</version>
+					<configuration>
+						<lifecycleMappingMetadata>
+							<pluginExecutions>
+								<pluginExecution>
+									<pluginExecutionFilter>
+										<groupId>com.atlassian.maven.plugins</groupId>
+										<artifactId>maven-amps-plugin</artifactId>
+										<versionRange>[5.0.13,)</versionRange>
+										<goals>
+											<goal>compress-resources</goal>
+											<goal>filter-plugin-descriptor</goal>
+											<goal>filter-test-plugin-descriptor</goal>
+											<goal>generate-rest-docs</goal>
+											<goal>copy-bundled-dependencies</goal>
+											<goal>copy-test-bundled-dependencies</goal>
+										</goals>
+									</pluginExecutionFilter>
+									<action>
+										<ignore />
+									</action>
+								</pluginExecution>
+							</pluginExecutions>
+						</lifecycleMappingMetadata>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
 	</build>
 	<properties>
-		<stash.version>2.10.1</stash.version>
-		<stash.data.version>2.2.0-m2</stash.data.version>
-		<amps.version>4.2.18</amps.version>
-		<plugin.testrunner.version>1.1</plugin.testrunner.version>
+		<stash.version>3.5.0</stash.version>
+		<stash.data.version>3.5.0</stash.data.version>
+	    <amps.version>5.0.13</amps.version>
+		<plugin.testrunner.version>1.2.3</plugin.testrunner.version>
 	</properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.harms.stash</groupId>
 	<artifactId>jenkins-integration-plugin</artifactId>
-	<version>1.0.7-SNAPSHOT</version>
+	<version>1.0.8-SNAPSHOT</version>
 	<packaging>atlassian-plugin</packaging>
 	<repositories>
 		<repository>
@@ -102,6 +102,11 @@
 			<artifactId>junit</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-context</artifactId>
+			<scope>provided</scope>
+		</dependency>
 		<!-- these are here to override transitive versions -->
 		<dependency>
 			<groupId>javax.ws.rs</groupId>
@@ -191,7 +196,7 @@
 	<properties>
 		<stash.version>3.5.0</stash.version>
 		<stash.data.version>3.5.0</stash.data.version>
-	    <amps.version>5.0.13</amps.version>
+		<amps.version>5.0.13</amps.version>
 		<plugin.testrunner.version>1.2.3</plugin.testrunner.version>
 	</properties>
 </project>

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobScheduler.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobScheduler.java
@@ -1,16 +1,22 @@
 package com.harms.stash.plugin.jenkins.job.intergration;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.atlassian.sal.api.scheduling.PluginJob;
-import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.scheduler.JobRunner;
+import com.atlassian.scheduler.JobRunnerRequest;
+import com.atlassian.scheduler.JobRunnerResponse;
+import com.atlassian.scheduler.config.JobRunnerKey;
 import com.atlassian.stash.pull.PullRequest;
 import com.atlassian.stash.pull.PullRequestService;
 import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.user.StashAuthenticationContext;
+import com.atlassian.stash.user.StashUser;
+import com.atlassian.stash.user.UserService;
 import com.atlassian.stash.util.Operation;
 import com.harms.stash.plugin.jenkins.job.settings.PluginSettingsHelper;
 
@@ -23,63 +29,69 @@ import com.harms.stash.plugin.jenkins.job.settings.PluginSettingsHelper;
  * @author fharms
  *
  */
-public class JenkinsJobScheduler implements PluginJob {
+public class JenkinsJobScheduler implements JobRunner {
+	public static final  JobRunnerKey jobRunnerKey = JobRunnerKey.of("com.harms.stash.plugin.jenkins.job.intergration:jenkins-job-intergration:ScheduleBuild");
     private static final Logger log = LoggerFactory.getLogger(JenkinsJobScheduler.class);
+	private final PullRequestService pullRequestService;
+	private final SecurityService securityService;
+	private final UserService userService;
+	private JobTrigger jenkinsCI;
+		
     
+    public JenkinsJobScheduler(PullRequestService pullRequestService, UserService userService,SecurityService securityService, JobTrigger jenkinsCiIntergration) {
+		this.pullRequestService = pullRequestService;
+		this.userService = userService;
+		this.securityService = securityService;
+		this.jenkinsCI = jenkinsCiIntergration;
+	}
     @Override
-    public void execute(Map<String, Object> jobDataMap) {
-        PullRequestService pullrequestService = (PullRequestService) jobDataMap.get("pullRequestService");
-        Long pullRequestId = (Long) jobDataMap.get("pullrequest_id");
-        Integer repositoryId = (Integer) jobDataMap.get("repository_id");
-        String slug = (String) jobDataMap.get("slug");
-        JenkinsJobTrigger jenkinsCI = (JenkinsJobTrigger) jobDataMap.get("JobTrigger");
-        TriggerRequestEvent eventType = (TriggerRequestEvent) jobDataMap.get("TriggerRequestEvent");
-        String userName = (String) jobDataMap.get("UserName");
-        SecurityService securityService = (SecurityService) jobDataMap.get("SecurityService");
-        String jobKey = PluginSettingsHelper.getScheduleJobKey(slug,pullRequestId);
-        
-        try {
-            securityService.doAsUser("background_trigger_jenkins_job", userName, new UserOperation(pullrequestService,jenkinsCI, pullRequestId, repositoryId, eventType));
-        } catch (Throwable e) {
-            log.error(String.format("Not able to execute the background job as user %s",userName, e));
-        } finally {
-            PluginSettingsHelper.resetScheduleTime(jobKey);
-        }
-        
-    }
-    
+	public JobRunnerResponse runJob(JobRunnerRequest request) {
+    	Map<String, Serializable> jobDataMap = request.getJobConfig().getParameters();
+         Long pullRequestId = (Long) jobDataMap.get("pullrequest_id");
+         Integer repositoryId = (Integer) jobDataMap.get("repository_id");
+         String slug = (String) jobDataMap.get("slug");
+         TriggerRequestEvent eventType = (TriggerRequestEvent) jobDataMap.get("TriggerRequestEvent");
+         StashUser user = userService.getUserByName((String) jobDataMap.get("User"));
+         String jobKey = PluginSettingsHelper.getScheduleJobKey(slug,pullRequestId);
+         
+         try {
+         	securityService.impersonating(user, "background_trigger_jenkins_job").call(new UserOperation(pullRequestService, jenkinsCI, pullRequestId, repositoryId, eventType));
+         } catch (Throwable e) {
+             log.error(String.format("Not able to execute the background job as user %s",user.getDisplayName(), e));
+         } finally {
+             PluginSettingsHelper.resetScheduleTime(jobKey);
+         }
+		return JobRunnerResponse.success();
+	}
+
     /**
      * Build a map of job data to be passed to the {@link JenkinsJobScheduler}
      * @param pr - The {@link PullRequest}
-     * @param jenkinsCiIntergration - The {@link JenkinsJobTrigger}
+     * @param event - The type of {@link TriggerRequestEvent}
      * @param pullRequestService - The {@link PullRequestService}
      * @param userManager - The {@link UserManager}
      * @param securityService - Then {@link SecurityService}
-     * @param event - The type of {@link TriggerRequestEvent}
      * @return A map with the job data
      */
-    static public Map<String, Object> buildJobDataMap(PullRequest pr, JobTrigger jenkinsCiIntergration, PullRequestService pullRequestService, UserManager userManager, SecurityService securityService, TriggerRequestEvent event) {
-        Map<String, Object> jobDataMap = new HashMap<String, Object>();
-        jobDataMap.put("JobTrigger", jenkinsCiIntergration);
-        jobDataMap.put("pullRequestService", pullRequestService);
+    static public Map<String, Serializable> buildJobDataMap(PullRequest pr, StashAuthenticationContext stashAuthenticationContext, TriggerRequestEvent event) {
+        Map<String, Serializable> jobDataMap = new HashMap<String, Serializable>();
         jobDataMap.put("pullrequest_id", pr.getId());
         jobDataMap.put("repository_id", pr.getFromRef().getRepository().getId());
         jobDataMap.put("slug", pr.getFromRef().getRepository().getSlug());
         jobDataMap.put("TriggerRequestEvent", event);
-        jobDataMap.put("UserName",userManager.getRemoteUser().getUsername());
-        jobDataMap.put("SecurityService",securityService);
+        jobDataMap.put("User",stashAuthenticationContext.getCurrentUser().getName());
         return jobDataMap;
     }
     
     private class UserOperation implements Operation<Object, Throwable> {
 
         private final TriggerRequestEvent eventType;
-        private final JenkinsJobTrigger jenkinsCI;
+        private final JobTrigger jenkinsCI;
         private final Long pullRequestId;
         private final Integer repositoryId;
         private final PullRequestService pullrequestService;
 
-        public UserOperation(PullRequestService pullrequestService, JenkinsJobTrigger jenkinsCI, Long pullRequestId, Integer repositoryId, TriggerRequestEvent eventType) {
+        public UserOperation(PullRequestService pullrequestService, JobTrigger jenkinsCI, Long pullRequestId, Integer repositoryId, TriggerRequestEvent eventType) {
             this.pullrequestService = pullrequestService;
             this.pullRequestId = pullRequestId;
             this.repositoryId = repositoryId;

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobSchedulerRegister.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobSchedulerRegister.java
@@ -1,0 +1,43 @@
+package com.harms.stash.plugin.jenkins.job.intergration;
+
+import org.springframework.beans.factory.DisposableBean;
+import org.springframework.beans.factory.InitializingBean;
+
+import com.atlassian.scheduler.SchedulerService;
+import com.atlassian.stash.pull.PullRequestService;
+import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.user.UserService;
+
+/**
+ * Register/unegister the Job Runner when the bean is Initializing / Disposable
+ * 
+ * @author fharms
+ *
+ */
+public class JenkinsJobSchedulerRegister implements DisposableBean, InitializingBean { 
+
+    private final SchedulerService schedulerService;
+	private final PullRequestService pullRequestService;
+	private final UserService userService;
+	private final SecurityService securityService;
+	private final JobTrigger jenkinsCiIntergration; 
+
+    public JenkinsJobSchedulerRegister(SchedulerService schedulerService, PullRequestService pullRequestService,UserService userService,SecurityService securityService,JobTrigger jenkinsCiIntergration) { 
+        this.schedulerService = schedulerService;
+		this.pullRequestService = pullRequestService;
+		this.userService = userService;
+		this.securityService = securityService;
+		this.jenkinsCiIntergration = jenkinsCiIntergration; 
+    } 
+
+    @Override 
+    public void afterPropertiesSet()  { 
+    	schedulerService.registerJobRunner(JenkinsJobScheduler.jobRunnerKey, new JenkinsJobScheduler(pullRequestService,userService,securityService,jenkinsCiIntergration));
+    	    
+    } 
+
+    @Override 
+    public void destroy() { 
+        schedulerService.unregisterJobRunner(JenkinsJobScheduler.jobRunnerKey); 
+    } 
+}

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobTrigger.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobTrigger.java
@@ -36,7 +36,9 @@ import com.atlassian.stash.pull.PullRequestService;
 import com.harms.stash.plugin.jenkins.job.settings.PluginSettingsHelper;
 
 final public class JenkinsJobTrigger implements JobTrigger {
-    private static final Logger log = LoggerFactory.getLogger(JenkinsJobTrigger.class);
+	private static final long serialVersionUID = 8685235357537808631L;
+
+	private transient static final Logger log = LoggerFactory.getLogger(JenkinsJobTrigger.class);
     
     private final PullRequestService pullRequestService;
     private final PluginSettings settings;

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobTrigger.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JenkinsJobTrigger.java
@@ -21,6 +21,9 @@ import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.impl.auth.BasicScheme;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.BasicHttpParams;
+import org.apache.http.params.HttpConnectionParams;
+import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.protocol.ExecutionContext;
 import org.apache.http.protocol.HttpContext;
@@ -198,11 +201,14 @@ final public class JenkinsJobTrigger implements JobTrigger {
     }
     
     private HttpResponse httpClientRequest(HttpRequestBase request, byte[] userName, byte[] password) throws IOException, ClientProtocolException {
-        DefaultHttpClient client;
-        client = new DefaultHttpClient();
+        HttpParams httpParams = new BasicHttpParams();
+        HttpConnectionParams.setConnectionTimeout(httpParams, 5000);
+        HttpConnectionParams.setSoTimeout(httpParams, 7000);
+         
+    	DefaultHttpClient client;
+        client = new DefaultHttpClient(httpParams);
 
         BasicHttpContext context = new BasicHttpContext();
-
         if (userName != null && password != null) {
             client.getCredentialsProvider().setCredentials(new AuthScope(AuthScope.ANY_HOST, AuthScope.ANY_PORT), new UsernamePasswordCredentials(new String(userName), new String(password)));
 

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JobTrigger.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/JobTrigger.java
@@ -1,12 +1,14 @@
 package com.harms.stash.plugin.jenkins.job.intergration;
 
+import java.io.Serializable;
+
 
 /**
  * 
  * @author fharms
  *
  */
-public interface JobTrigger {
+public interface JobTrigger extends Serializable {
 
     /**
      * @return the next CI server from the list of servers

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/StashEventListener.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/StashEventListener.java
@@ -24,11 +24,8 @@ import com.atlassian.stash.event.pull.PullRequestOpenedEvent;
 import com.atlassian.stash.event.pull.PullRequestReopenedEvent;
 import com.atlassian.stash.event.pull.PullRequestRescopedEvent;
 import com.atlassian.stash.pull.PullRequest;
-import com.atlassian.stash.pull.PullRequestService;
 import com.atlassian.stash.repository.Repository;
-import com.atlassian.stash.user.SecurityService;
 import com.atlassian.stash.user.StashAuthenticationContext;
-import com.atlassian.stash.user.UserService;
 import com.harms.stash.plugin.jenkins.job.settings.PluginSettingsHelper;
 
 public class StashEventListener {
@@ -38,11 +35,10 @@ public class StashEventListener {
     private final SchedulerService schedulerService;
     private final StashAuthenticationContext stashAuthContext;
     
-    public StashEventListener(PluginSettingsFactory pluginSettingsFactory, JobTrigger jenkinsCiIntergration, SchedulerService pluginScheduler,StashAuthenticationContext stashAuthContext,SecurityService securityService, PullRequestService pullRequestService,UserService userService) {
+    public StashEventListener(PluginSettingsFactory pluginSettingsFactory, SchedulerService pluginScheduler,StashAuthenticationContext stashAuthContext) {
         this.schedulerService = pluginScheduler;
         this.settings = pluginSettingsFactory.createGlobalSettings();
         this.stashAuthContext = stashAuthContext;
-        pluginScheduler.registerJobRunner(JenkinsJobScheduler.jobRunnerKey, new JenkinsJobScheduler(pullRequestService,userService,securityService,jenkinsCiIntergration));
     }
     
     /**

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/StashEventListener.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/intergration/StashEventListener.java
@@ -1,6 +1,8 @@
 package com.harms.stash.plugin.jenkins.job.intergration;
 
+import java.io.Serializable;
 import java.util.Calendar;
+import java.util.Date;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -9,8 +11,12 @@ import org.slf4j.LoggerFactory;
 import com.atlassian.event.api.EventListener;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
-import com.atlassian.sal.api.scheduling.PluginScheduler;
-import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.scheduler.SchedulerService;
+import com.atlassian.scheduler.SchedulerServiceException;
+import com.atlassian.scheduler.config.JobConfig;
+import com.atlassian.scheduler.config.JobId;
+import com.atlassian.scheduler.config.RunMode;
+import com.atlassian.scheduler.config.Schedule;
 import com.atlassian.stash.event.pull.PullRequestDeclinedEvent;
 import com.atlassian.stash.event.pull.PullRequestEvent;
 import com.atlassian.stash.event.pull.PullRequestMergedEvent;
@@ -21,26 +27,22 @@ import com.atlassian.stash.pull.PullRequest;
 import com.atlassian.stash.pull.PullRequestService;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.user.StashAuthenticationContext;
+import com.atlassian.stash.user.UserService;
 import com.harms.stash.plugin.jenkins.job.settings.PluginSettingsHelper;
 
 public class StashEventListener {
-    @SuppressWarnings("unused")
     private static final Logger log = LoggerFactory.getLogger(StashEventListener.class);
     
-    private final JobTrigger jenkinsCI;
     private final PluginSettings settings;
-    private final PluginScheduler pluginScheduler;
-    private final UserManager userManager;
-    private final SecurityService securityService;
-    private final PullRequestService pullRequestService;
+    private final SchedulerService schedulerService;
+    private final StashAuthenticationContext stashAuthContext;
     
-    public StashEventListener(PluginSettingsFactory pluginSettingsFactory, JobTrigger jenkinsCiIntergration, PluginScheduler pluginScheduler,UserManager userManager,SecurityService securityService, PullRequestService pullRequestService) {
-        this.pluginScheduler = pluginScheduler;
-        this.pullRequestService = pullRequestService;
+    public StashEventListener(PluginSettingsFactory pluginSettingsFactory, JobTrigger jenkinsCiIntergration, SchedulerService pluginScheduler,StashAuthenticationContext stashAuthContext,SecurityService securityService, PullRequestService pullRequestService,UserService userService) {
+        this.schedulerService = pluginScheduler;
         this.settings = pluginSettingsFactory.createGlobalSettings();
-        this.jenkinsCI = jenkinsCiIntergration;
-        this.userManager = userManager;
-        this.securityService = securityService;
+        this.stashAuthContext = stashAuthContext;
+        pluginScheduler.registerJobRunner(JenkinsJobScheduler.jobRunnerKey, new JenkinsJobScheduler(pullRequestService,userService,securityService,jenkinsCiIntergration));
     }
     
     /**
@@ -63,6 +65,12 @@ public class StashEventListener {
     public void openPullRequest(PullRequestOpenedEvent pushEvent)
     {
         PullRequestData prd = new PullRequestData(pushEvent.getPullRequest());
+        
+        boolean isDisableAutomaticBuildByDefault = PluginSettingsHelper.isDisableAutomaticBuildByDefault(prd.slug,settings);
+        if (isDisableAutomaticBuildByDefault) {
+        	PluginSettingsHelper.enableAutomaticBuildFlag(prd.projectKey, prd.slug, prd.pullRequestId, settings);
+        	return;
+        }
         
         boolean triggerBuildOnCreate = PluginSettingsHelper.isTriggerBuildOnCreate(prd.slug,settings);
         if (triggerBuildOnCreate) {
@@ -89,8 +97,13 @@ public class StashEventListener {
     {
         PullRequestData prd = new PullRequestData(pushEvent.getPullRequest());
         
-        boolean automaticBuildDisabled = PluginSettingsHelper.isAutomaticBuildDisabled(prd.projectKey,prd.slug,prd.pullRequestId,settings);
+        boolean isDisableAutomaticBuildByDefault = PluginSettingsHelper.isDisableAutomaticBuildByDefault(prd.slug,settings);
+        if (isDisableAutomaticBuildByDefault) {
+        	PluginSettingsHelper.enableAutomaticBuildFlag(prd.projectKey, prd.slug, prd.pullRequestId, settings);
+        	return;
+        }
         
+        boolean automaticBuildDisabled = PluginSettingsHelper.isAutomaticBuildDisabled(prd.projectKey,prd.slug,prd.pullRequestId,settings);
         boolean triggerBuildOnReopen = PluginSettingsHelper.isTriggerBuildOnReopen(prd.slug,settings);
         if (triggerBuildOnReopen && !automaticBuildDisabled) {
             scheduleJobTrigger(pushEvent, prd);
@@ -103,10 +116,21 @@ public class StashEventListener {
      * @param prd
      */
     private void scheduleJobTrigger(PullRequestEvent pushEvent, PullRequestData prd) {
-        final Calendar scheduleJobTime = PluginSettingsHelper.getScheduleJobTime(PluginSettingsHelper.getScheduleJobKey(prd.slug,prd.pullRequestId));
+    	String scheduleJobKey = PluginSettingsHelper.getScheduleJobKey(prd.slug,prd.pullRequestId);
+		final Calendar scheduleJobTime = PluginSettingsHelper.getScheduleJobTime(scheduleJobKey);
         if ((scheduleJobTime == null) || (System.currentTimeMillis() > scheduleJobTime.getTime().getTime())) {
-            Map<String, Object> jobData = JenkinsJobScheduler.buildJobDataMap(pushEvent.getPullRequest(),jenkinsCI,pullRequestService,userManager,securityService, getTriggerEventType(pushEvent));
-            pluginScheduler.scheduleJob(PluginSettingsHelper.getScheduleJobKey(prd.slug,prd.pullRequestId), JenkinsJobScheduler.class, jobData, PluginSettingsHelper.generateScheduleJobTime(prd.slug, settings, prd.pullRequestId), 0);
+            Map<String, Serializable> jobData = JenkinsJobScheduler.buildJobDataMap(pushEvent.getPullRequest(),stashAuthContext,getTriggerEventType(pushEvent));
+            Date jobTime = PluginSettingsHelper.generateScheduleJobTime(prd.slug, settings, prd.pullRequestId);
+            try {
+    			schedulerService.scheduleJob( 
+    					JobId.of(scheduleJobKey), 
+    			        JobConfig.forJobRunnerKey(JenkinsJobScheduler.jobRunnerKey) 
+    			                .withParameters(jobData)
+    			                .withRunMode(RunMode.RUN_ONCE_PER_CLUSTER) 
+    			                .withSchedule(Schedule.runOnce(jobTime)));
+    		} catch (SchedulerServiceException e) {
+    			log.error(String.format("Not able to schedule jenkins build with job id %s at %t",scheduleJobKey,jobTime));
+    		}
         }
     }
     

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/CryptoHelp.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/CryptoHelp.java
@@ -13,10 +13,10 @@ import javax.crypto.spec.IvParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
 
 import org.apache.commons.codec.Charsets;
+import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.sun.jersey.core.util.Base64;
 
 /**
  * Encrypt and Decrypt a values base on it's key. 
@@ -71,7 +71,7 @@ public class CryptoHelp {
         SecretKeySpec skeySpec = new SecretKeySpec(key, "AES");
         Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
         cipher.init(Cipher.ENCRYPT_MODE, skeySpec, iv);
-        return Base64.encode(cipher.doFinal(value));
+        return Base64.encodeBase64(cipher.doFinal(value));
     }
 
     public static byte[] decrypt(byte[] key, byte[] value) throws GeneralSecurityException {
@@ -85,7 +85,7 @@ public class CryptoHelp {
     
             Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
             cipher.init(Cipher.DECRYPT_MODE, skeySpec, iv);
-            byte[] original = cipher.doFinal(Base64.decode(value));
+            byte[] original = cipher.doFinal(Base64.decodeBase64(value));
     
             return original;
         }

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/PluginSettingsHelper.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/PluginSettingsHelper.java
@@ -389,6 +389,7 @@ public class PluginSettingsHelper {
         pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.BUILD_REF_FIELD,slug));
         pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.JENKINS_PR_URL_FIELD,slug));
         pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.BUILD_DELAY_FIELD,slug));
+        pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.DISABLE_AUTOMATIC_BUILD_BY_DEFAULT,slug));
         pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.TRIGGER_BUILD_ON_CREATE,slug));
         pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.TRIGGER_BUILD_ON_UPDATE,slug));
         pluginSettings.remove(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.TRIGGER_BUILD_ON_REOPEN,slug));

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/PluginSettingsHelper.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/PluginSettingsHelper.java
@@ -32,6 +32,7 @@ public class PluginSettingsHelper {
     public static final String TRIGGER_BUILD_ON_CREATE = PLUGIN_STORAGE_KEY + ".triggerBuildOnCreate";
     public static final String TRIGGER_BUILD_ON_UPDATE = PLUGIN_STORAGE_KEY + ".triggerBuildOnUpdate";
     public static final String TRIGGER_BUILD_ON_REOPEN = PLUGIN_STORAGE_KEY + ".triggerBuildOnReopen";
+    public static final String DISABLE_AUTOMATIC_BUILD_BY_DEFAULT = PLUGIN_STORAGE_KEY + ".disableAutomaticBuildByDefault";
     private static final String JENKINS_PR_URL_FIELD = PLUGIN_STORAGE_KEY + ".jenkinsPRUrl";
     
     private static final String BUILD_DELAY_FIELD = PLUGIN_STORAGE_KEY + ".buildDelayField";
@@ -181,6 +182,17 @@ public class PluginSettingsHelper {
         }
     }
     
+    
+    /**
+     * Return true if the disable build by default is enabled for the plug-in
+     * @param slug
+     * @param settings
+     * @return
+     */
+    public static boolean isDisableAutomaticBuildByDefault(String slug, PluginSettings settings) {
+        return (CHECKED.equals(settings.get(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.DISABLE_AUTOMATIC_BUILD_BY_DEFAULT,slug))));
+    }
+    
     /**
      * Return true if the trigger on create flag is enabled for the plug-in
      * @param slug
@@ -317,6 +329,14 @@ public class PluginSettingsHelper {
         settings.put(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.JENKINS_LAST_CI_SERVER,slug), lastCiServer);
     }
     
+    /**
+     * Enable the disable build by default
+     * @param slug
+     * @param settings
+     */
+    public static void enableDisableAutomaticBuildByDefault(String slug, PluginSettings settings) {
+        settings.put(PluginSettingsHelper.getPluginKey(PluginSettingsHelper.DISABLE_AUTOMATIC_BUILD_BY_DEFAULT, slug), CHECKED);
+    }
     /**
      * Enable it should trigger a build when a pull-request is created
      * @param slug

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/JenkinsIntegrationPluginSettingsServlet.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/JenkinsIntegrationPluginSettingsServlet.java
@@ -13,11 +13,11 @@ import org.slf4j.LoggerFactory;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
-import com.atlassian.sal.api.user.UserManager;
 import com.atlassian.soy.renderer.SoyException;
 import com.atlassian.soy.renderer.SoyTemplateRenderer;
 import com.atlassian.stash.repository.Repository;
 import com.atlassian.stash.repository.RepositoryService;
+import com.atlassian.stash.user.StashAuthenticationContext;
 import com.google.common.collect.Maps;
 import com.harms.stash.plugin.jenkins.job.settings.DecryptException;
 import com.harms.stash.plugin.jenkins.job.settings.EncryptException;
@@ -37,8 +37,8 @@ public class JenkinsIntegrationPluginSettingsServlet extends JenkinsStashBaseSer
     private final PluginSettingsFactory pluginSettingsFactory;
     private final UpgradeService upgradeService;
 
-    public JenkinsIntegrationPluginSettingsServlet(SoyTemplateRenderer soyTemplateRenderer, RepositoryService repositoryService, PluginSettingsFactory pluginSettingsFactory, UserManager userManager, LoginUriProvider loginUriProvider) {
-        super(loginUriProvider, userManager);
+    public JenkinsIntegrationPluginSettingsServlet(SoyTemplateRenderer soyTemplateRenderer, RepositoryService repositoryService, PluginSettingsFactory pluginSettingsFactory, StashAuthenticationContext stashAuthContext, LoginUriProvider loginUriProvider) {
+        super(loginUriProvider, stashAuthContext);
         this.soyTemplateRenderer = soyTemplateRenderer;
         this.repositoryService = repositoryService;
         this.pluginSettingsFactory = pluginSettingsFactory;
@@ -109,6 +109,10 @@ public class JenkinsIntegrationPluginSettingsServlet extends JenkinsStashBaseSer
         
         PluginSettingsHelper.setBuildReferenceField(slug, parameterMap.get("buildRefField")[0], ps);
         PluginSettingsHelper.setBuildDelay(slug, new Integer(parameterMap.get("buildDelayField")[0]), ps);
+        
+        if (parameterMap.containsKey("disableAutomaticBuildByDefault")) {
+            PluginSettingsHelper.enableDisableAutomaticBuildByDefault(slug, ps);
+        }
         
         if (parameterMap.containsKey("triggerBuildOnCreate")) {
             PluginSettingsHelper.enableTriggerOnCreate(slug, ps);
@@ -233,6 +237,10 @@ public class JenkinsIntegrationPluginSettingsServlet extends JenkinsStashBaseSer
         context.put("buildTitleField", PluginSettingsHelper.getBuildTitleField(slug, pluginSettings));
         context.put("buildPullRequestUrlField", PluginSettingsHelper.getPullRequestUrlFieldName(slug, pluginSettings));
         
+        if (PluginSettingsHelper.isDisableAutomaticBuildByDefault(slug, pluginSettings)){
+            context.put("disableAutomaticBuildByDefault", "checked=\"checked\"");
+        } 
+        
         if (PluginSettingsHelper.isTriggerBuildOnCreate(slug, pluginSettings)){
             context.put("triggerBuildOnCreate", "checked=\"checked\"");
         } 
@@ -255,6 +263,7 @@ public class JenkinsIntegrationPluginSettingsServlet extends JenkinsStashBaseSer
         context.put("buildTitleField", "");
         context.put("jenkinsBaseUrl", "");
         context.put("jenkinsCIServerList",null);
+        context.put("disableAutomaticBuildByDefault", "");
         context.put("triggerBuildOnCreate", "");
         context.put("triggerBuildOnUpdate", "");
         context.put("triggerBuildOnReopen", "");

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/JenkinsStashBaseServlet.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/JenkinsStashBaseServlet.java
@@ -10,17 +10,16 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import com.atlassian.sal.api.auth.LoginUriProvider;
-import com.atlassian.sal.api.user.UserManager;
-import com.atlassian.sal.api.user.UserProfile;
+import com.atlassian.stash.user.StashAuthenticationContext;
 
 public class JenkinsStashBaseServlet extends HttpServlet {
     private static final long serialVersionUID = 49L;
     protected final LoginUriProvider loginUriProvider;
-    protected final UserManager userManager;
+    protected final StashAuthenticationContext stashAuthContext;
     
-    public JenkinsStashBaseServlet(LoginUriProvider loginUriProvider, UserManager userManager) {
+    public JenkinsStashBaseServlet(LoginUriProvider loginUriProvider, StashAuthenticationContext stashAuthContext) {
         this.loginUriProvider = loginUriProvider;
-        this.userManager = userManager;
+        this.stashAuthContext = stashAuthContext;
     }
     
     protected void redirectToLogin(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException
@@ -48,8 +47,7 @@ public class JenkinsStashBaseServlet extends HttpServlet {
     
     @Override
     protected void service(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
-        UserProfile user = userManager.getRemoteUser(req);
-        if (user == null) {
+        if (!stashAuthContext.isAuthenticated()) {
             redirectToLogin(req, resp);
             return;
         }

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/ManualTriggerBuildServlet.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/ManualTriggerBuildServlet.java
@@ -1,7 +1,9 @@
 package com.harms.stash.plugin.jenkins.job.settings.servlet;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.Map;
 
 import javax.servlet.ServletException;
@@ -14,11 +16,17 @@ import org.slf4j.LoggerFactory;
 import com.atlassian.sal.api.auth.LoginUriProvider;
 import com.atlassian.sal.api.pluginsettings.PluginSettings;
 import com.atlassian.sal.api.pluginsettings.PluginSettingsFactory;
-import com.atlassian.sal.api.scheduling.PluginScheduler;
-import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.scheduler.SchedulerService;
+import com.atlassian.scheduler.SchedulerServiceException;
+import com.atlassian.scheduler.config.JobConfig;
+import com.atlassian.scheduler.config.JobId;
+import com.atlassian.scheduler.config.RunMode;
+import com.atlassian.scheduler.config.Schedule;
 import com.atlassian.stash.pull.PullRequest;
 import com.atlassian.stash.pull.PullRequestService;
 import com.atlassian.stash.user.SecurityService;
+import com.atlassian.stash.user.StashAuthenticationContext;
+import com.atlassian.stash.user.UserService;
 import com.harms.stash.plugin.jenkins.job.intergration.JenkinsJobScheduler;
 import com.harms.stash.plugin.jenkins.job.intergration.JobTrigger;
 import com.harms.stash.plugin.jenkins.job.intergration.TriggerRequestEvent;
@@ -35,22 +43,20 @@ public class ManualTriggerBuildServlet extends JenkinsStashBaseServlet {
     private static final Logger log = LoggerFactory.getLogger(ManualTriggerBuildServlet.class);
     
     private static final long serialVersionUID = -6947257382708409328L;
-    private final JobTrigger jenkinsCiIntergration;
     private final PullRequestService pullRequestService;
-    private final PluginScheduler pluginScheduler;
+    private final SchedulerService schedulerService;
     private final PluginSettings settings;
-    
-    private final SecurityService securityService;
 
     
-    public ManualTriggerBuildServlet(JobTrigger jenkinsCiIntergration, PullRequestService pullRequestService, PluginScheduler pluginScheduler, PluginSettingsFactory pluginSettingsFactory,UserManager userManager,SecurityService securityService,LoginUriProvider loginUriProvider) {
-        super(loginUriProvider, userManager);
+    public ManualTriggerBuildServlet(JobTrigger jenkinsCiIntergration, PullRequestService pullRequestService, SchedulerService schedulerService, PluginSettingsFactory pluginSettingsFactory,StashAuthenticationContext stashAuthContext,SecurityService securityService,LoginUriProvider loginUriProvider, UserService userService) {
+        super(loginUriProvider, stashAuthContext);
         log.debug("invoked constructor");
-        this.securityService = securityService;
-        this.pluginScheduler = pluginScheduler;
+        this.schedulerService = schedulerService;
         this.pullRequestService = pullRequestService;
-        this.jenkinsCiIntergration = jenkinsCiIntergration;
         this.settings = pluginSettingsFactory.createGlobalSettings();
+        
+        schedulerService.registerJobRunner(JenkinsJobScheduler.jobRunnerKey, new JenkinsJobScheduler(pullRequestService,userService,securityService,jenkinsCiIntergration));
+        
     }
     
     @Override
@@ -76,17 +82,46 @@ public class ManualTriggerBuildServlet extends JenkinsStashBaseServlet {
             log.debug(String.format("Retrieved pull request information for %s", pullRequest.getId()));
             String slug = pullRequest.getFromRef().getRepository().getSlug();
             String scheduleJobKey = PluginSettingsHelper.getScheduleJobKey(slug,pullRequestId);
+            JobId jobKey = JobId.of(scheduleJobKey);
+           
+            unscheduleJob(scheduleJobKey, jobKey);
+            
+            Map<String, Serializable> jobData = JenkinsJobScheduler.buildJobDataMap(pullRequest,stashAuthContext,TriggerRequestEvent.FORCED_BUILD);
+            Date jobTime = PluginSettingsHelper.setScheduleJobTime(slug, settings, pullRequestId,30);
             try {
-             pluginScheduler.unscheduleJob(scheduleJobKey); //Unscheduled the current job if any 
-            } catch (IllegalArgumentException e) {
-             log.debug("No current job was scheduled for job id "+scheduleJobKey);  
-            }
-            Map<String, Object> jobData = JenkinsJobScheduler.buildJobDataMap(pullRequest,jenkinsCiIntergration,pullRequestService,userManager,securityService,TriggerRequestEvent.FORCED_BUILD);
-            pluginScheduler.scheduleJob(scheduleJobKey, JenkinsJobScheduler.class, jobData,PluginSettingsHelper.setScheduleJobTime(slug, settings, pullRequestId,0), 0);
-            resp.setStatus(HttpServletResponse.SC_OK);
+				scheduleJob(pullRequestId, slug, scheduleJobKey, jobKey,jobData, jobTime);
+				resp.setStatus(HttpServletResponse.SC_OK);
+			} catch (SchedulerServiceException e) {
+			    resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, String.format("Not able to schedule jenkins build with job id %1$s at %2$tH:%2$tM:%2$tS",scheduleJobKey,jobTime));
+				resp.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+			}
+            
         } else {
-            log.error(String.format("Not able to retrieve the pull-reqeust based on the repository id %s and pull-request id %s",repositoryId,pullRequestId));
-            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, String.format("Not able to retrieve the pull-reqeust based on the repository id %s and pull-request id %s",repositoryId,pullRequestId));
+            String errorMsg = String.format("Not able to retrieve the pull-reqeust based on the repository id %s and pull-request id %s",repositoryId,pullRequestId);
+			log.error(errorMsg);
+            resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR, errorMsg);
         }
     }
+
+	private void scheduleJob(Long pullRequestId,String slug, String scheduleJobKey, JobId jobKey,Map<String, Serializable> jobData, Date jobTime) throws IOException, SchedulerServiceException {
+		try {
+			schedulerService.scheduleJob( 
+			        jobKey, 
+			        JobConfig.forJobRunnerKey(JenkinsJobScheduler.jobRunnerKey) 
+			                .withParameters(jobData)
+			                .withRunMode(RunMode.RUN_ONCE_PER_CLUSTER) 
+			                .withSchedule(Schedule.runOnce(jobTime)));
+		} catch (SchedulerServiceException e) {
+			log.error(String.format("Not able to schedule jenkins build with job id %1$s at %2$tH:%2$tM:%2$tS",scheduleJobKey,jobTime),e);
+			throw e;
+		}
+	}
+
+	private void unscheduleJob(String scheduleJobKey, JobId jobKey) {
+		try {
+			schedulerService.unscheduleJob(jobKey); //Unscheduled the current job if any 
+		} catch (IllegalArgumentException e) {
+			log.debug("No current job was scheduled for job id "+scheduleJobKey);  
+		}
+	}
 }

--- a/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/ScheduledJobTriggerInfoServlet.java
+++ b/src/main/java/com/harms/stash/plugin/jenkins/job/settings/servlet/ScheduledJobTriggerInfoServlet.java
@@ -13,7 +13,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.atlassian.sal.api.auth.LoginUriProvider;
-import com.atlassian.sal.api.user.UserManager;
+import com.atlassian.stash.user.StashAuthenticationContext;
 import com.harms.stash.plugin.jenkins.job.settings.PluginSettingsHelper;
 
 /**
@@ -30,8 +30,8 @@ public class ScheduledJobTriggerInfoServlet extends JenkinsStashBaseServlet {
     private static final long serialVersionUID = 604820129001885579L;
     private static final Logger log = LoggerFactory.getLogger(ScheduledJobTriggerInfoServlet.class);
     
-    public ScheduledJobTriggerInfoServlet(LoginUriProvider loginUriProvider, UserManager userManager) {
-     super(loginUriProvider, userManager);
+    public ScheduledJobTriggerInfoServlet(LoginUriProvider loginUriProvider, StashAuthenticationContext stashAuthContext) {
+     super(loginUriProvider, stashAuthContext);
     }
     
     @Override

--- a/src/main/resources/atlassian-plugin.xml
+++ b/src/main/resources/atlassian-plugin.xml
@@ -12,10 +12,8 @@
     <component-import key="soyTemplateRenderer" interface="com.atlassian.soy.renderer.SoyTemplateRenderer"/>
     <component-import key="repositoryService" interface="com.atlassian.stash.repository.RepositoryService"/>
     <component-import key="pullRequestService" interface="com.atlassian.stash.pull.PullRequestService"/>
-    <component-import key="userManager" interface="com.atlassian.sal.api.user.UserManager"/>
     <component-import key="pluginSettingsFactory" interface="com.atlassian.sal.api.pluginsettings.PluginSettingsFactory"/>
-    <component-import key="pluginScheduler" interface="com.atlassian.sal.api.scheduling.PluginScheduler"/>
-    <component-import key="securityService" interface="com.atlassian.stash.user.SecurityService"/>
+    <component-import key="schedulerService" interface="com.atlassian.scheduler.SchedulerService"/>
     <component-import key="webResourceUrlProvider" interface="com.atlassian.plugin.webresource.WebResourceUrlProvider"/>
     <component-import key="loginUriProvider" name="Login URI provider" interface="com.atlassian.sal.api.auth.LoginUriProvider" />
     

--- a/src/main/resources/static/jenkins-config.soy
+++ b/src/main/resources/static/jenkins-config.soy
@@ -11,6 +11,7 @@
  * @param triggerBuildOnCreate True if a build should triggered when pull request is created  
  * @param triggerBuildOnUpdate True if a build should triggered when pull request is updated
  * @param triggerBuildOnReopen True if a build should triggered when pull request is reopen
+ * @param disableAutomaticBuildByDefault True if the "Disable automatic build" is enabled
  * @param buildPullRequestUrlField Pull-request URL field
  */
 {template .repositorySettings}
@@ -28,6 +29,11 @@
 <div id="aui-message-bar"></div>    
 <form action="#" method="post" id="jenkinsconfigform" class="aui">
     <fieldset>
+        <div class="field-group">
+            <label for="disableAutomaticBuildByDefault">Enable 'Disable automatic build'</label>
+            <input class="checkbox" type="checkbox" id="disableAutomaticBuildByDefault" name="disableAutomaticBuildByDefault" {$disableAutomaticBuildByDefault}">
+            <div class="description">Enable by default 'Disable automatic build'</div>
+        </div>
         <div class="field-group">
             <label for="triggerBuildOnCreate">Trigger on new pull-request</label>
             <input class="checkbox" type="checkbox" id="triggerBuildOnCreate" name="triggerBuildOnCreate" {$triggerBuildOnCreate}">

--- a/src/main/resources/static/pull-request-overview.soy
+++ b/src/main/resources/static/pull-request-overview.soy
@@ -7,7 +7,7 @@
 	<div class="plugin-item">
 	    <form class="aui" id="disable-build">
 	    	<div class="plugin-item">
-	        <input class="disablecheckbox" type="checkbox" id="disablecheckbox_id" name="disableAutomaticBuild">
+	        <input class="disablecheckbox" type="checkbox" id="disablecheckbox_id" name="disableAutomaticBuild" checked>
 	    	<label>Disable automatic build</label>
 	    	</div>
 	    	<div class="plugin-item">


### PR DESCRIPTION
There has been significant API changes to the latest releases of Stash. 
- The scheduler API support cluster scheduling and the code need to be re-factored to match the new API's
- The User service API has also changed and now the Security Service API
and StashAuthenticationContext API is used instead
- Increase version to 1.0.8